### PR TITLE
Added Method for WebService Excel-Headers

### DIFF
--- a/src/main/java/dina/LabelCreator/LabelCreator.java
+++ b/src/main/java/dina/LabelCreator/LabelCreator.java
@@ -148,23 +148,30 @@ public class LabelCreator {
 	}
 	
 	public String createHeaders(){
-		String line;
-		System.out.println("createHeader");
-		try {
-			BufferedReader reader = new BufferedReader(new FileReader(tmpPath));
-			while ((line = reader.readLine()) != null){}
-			reader.close();
-		}
-		catch(IOException e){
-			e.printStackTrace();
-			return null;
+		System.out.println("Excel Headers");
+		String file1 = new File(templateFile).getAbsolutePath();
+		File file = new File(
+            file1);
+		String content;
+		try{
+		BufferedReader br = new BufferedReader(new FileReader(templateFile));
+		String st;
+		
+		content = "";
+		while ((st = br.readLine()) != null)
+			content += st;
+		br.close();
+		}catch(Exception e){
+			content = "Error in reading file";
+			return content;
 		}
 
-		if (line != null){
-			return line;
-		}
+		System.out.println(content);
+		int start = content.indexOf("Excel-Header:") +13;
+		int end = content.indexOf("Excel-Header-End");
+		String headers = content.substring(start, end);
+		return headers;
 		
-		return "line was null from path: " + new File(templateFile).getAbsolutePath() + templateFile + tmpPath + tmpDir ;
 		
 	}
 	public void setData(String data) {

--- a/src/main/java/dina/LabelCreator/LabelCreator.java
+++ b/src/main/java/dina/LabelCreator/LabelCreator.java
@@ -3,6 +3,10 @@
  */
 package dina.LabelCreator;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+//new dependencies
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -82,7 +86,7 @@ public class LabelCreator {
 	public void createPDF()
 	{
 		    String template = new String();
-            
+            System.out.println("createPDF");
             OutputStream os = null;
               try {
                os = new FileOutputStream(outputFile);
@@ -143,7 +147,26 @@ public class LabelCreator {
 		return twig;
 	}
 	
-	
+	public String createHeaders(){
+		String line;
+		System.out.println("createHeader");
+		try {
+			BufferedReader reader = new BufferedReader(new FileReader(tmpPath));
+			while ((line = reader.readLine()) != null){}
+			reader.close();
+		}
+		catch(IOException e){
+			e.printStackTrace();
+			return null;
+		}
+
+		if (line != null){
+			return line;
+		}
+		
+		return "line was null from path: " + new File(templateFile).getAbsolutePath() + templateFile + tmpPath + tmpDir ;
+		
+	}
 	public void setData(String data) {
 		
 		if(data==null || data.isEmpty())

--- a/src/main/java/dina/api/requests/CreateHEADER.java
+++ b/src/main/java/dina/api/requests/CreateHEADER.java
@@ -34,7 +34,7 @@ public class CreateHEADER{
 
            String re = labels.createHeaders();
            
-		   return "This was a success \n" + " Or not? " + re;
+		   return re;
 	}
 	
 	public List<String> getCleanUp(){

--- a/src/main/java/dina/api/requests/CreateHEADER.java
+++ b/src/main/java/dina/api/requests/CreateHEADER.java
@@ -1,0 +1,44 @@
+package dina.api.requests;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import dina.LabelCreator.LabelCreator;
+import dina.LabelCreator.Options.Options;
+import spark.Request;
+import spark.Response;
+
+public class CreateHEADER{
+
+	public String template;
+	private Options op;
+	private Request req;
+	private Response res;
+    private List<String> codesForCleanUp = new ArrayList<>();
+	
+	public CreateHEADER(Options options, Request request, Response response) {
+		op = options;
+		req = request;
+		res = response;
+	}
+
+	public String result() throws IOException {
+		   
+			if(req.queryParams("template")!=null)
+			   op.templateFile = op.templateDir+"/"+req.queryParams("template");
+		
+		   LabelCreator labels = new LabelCreator(op, req.queryParams("data"));
+		   labels.baseURL = op.baseURL;
+		   
+
+           String re = labels.createHeaders();
+           
+		   return "This was a success \n" + re;
+	}
+	
+	public List<String> getCleanUp(){
+		
+		return codesForCleanUp;
+	}
+}

--- a/src/main/java/dina/api/requests/CreateHEADER.java
+++ b/src/main/java/dina/api/requests/CreateHEADER.java
@@ -34,7 +34,7 @@ public class CreateHEADER{
 
            String re = labels.createHeaders();
            
-		   return "This was a success \n" + re;
+		   return "This was a success \n" + " Or not? " + re;
 	}
 	
 	public List<String> getCleanUp(){

--- a/src/main/java/dina/api/routes/CreateHEADERRoute.java
+++ b/src/main/java/dina/api/routes/CreateHEADERRoute.java
@@ -1,0 +1,61 @@
+package dina.api.routes;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import dina.LabelCreator.Options.Options;
+import dina.api.ApiResponseCode;
+import dina.api.requests.CreateHEADER;
+import dina.api.requests.CreateHTML;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+@Api
+@Path("/header")
+@Produces("text/plain")
+public class CreateHEADERRoute implements Route {
+
+	@POST
+	@ApiOperation(value = "Creates ExcelHeaders", nickname="CreateHEADER")
+	@ApiImplicitParams({ //
+			@ApiImplicitParam(required = true, dataType="string", name="auth", paramType = "header"), //
+			@ApiImplicitParam(required = true, dataType = "dina.api.requests.CreateHEADER", paramType = "body") //
+	}) //
+	@ApiResponses(value = { //
+			@ApiResponse(code = 200, message = "Success", response=CreateHEADER.class), //
+			@ApiResponse(code = 400, message = "Invalid input data", response=ApiResponseCode.class), //
+			@ApiResponse(code = 401, message = "Unauthorized", response=ApiResponseCode.class), //
+			@ApiResponse(code = 404, message = "Not found", response=ApiResponseCode.class) //
+	})
+
+	public CreateHEADER handle(@ApiParam(hidden=true) Request request, @ApiParam(hidden=true)Response response) throws Exception {
+		return new CreateHEADER(null, request, response);
+	}
+	
+	public static void route(@ApiParam(hidden=true) Options op) throws Exception {
+		
+	spark.Spark.post("/header", (req, res) -> {
+			
+			CreateHEADER c = new CreateHEADER(op, req, res);
+			String re = c.result();
+			
+			return re;
+     });
+		
+		spark.Spark.get("/header", (req, res) -> {
+			// CreateHTML c = new CreateHTML(op, req, res);
+	         //  return c.result();
+			   return "Please use POST method.";
+	     });
+	}
+	
+}

--- a/src/main/java/labels/Main.java
+++ b/src/main/java/labels/Main.java
@@ -150,6 +150,16 @@ public class Main {
 	    						// TODO Auto-generated catch block
 	    						e.printStackTrace();
 	    					}
+						if(format.equalsIgnoreCase("excel"))
+	    					try {
+								
+	    						CreateHEADER c = new CreateHEADER(op, req, res);
+	    				        return c.result();
+								
+	    					} catch (Exception e) {
+	    						// TODO Auto-generated catch block
+	    						e.printStackTrace();
+	    					}
     				}
     				return "3rror";
     			});

--- a/src/main/java/labels/Main.java
+++ b/src/main/java/labels/Main.java
@@ -25,9 +25,11 @@ import dina.TemplateCreator.TemplateCreator;
 import dina.api.SwaggerParser;
 import dina.api.requests.AccessStatic;
 import dina.api.requests.AccessTmp;
+import dina.api.requests.CreateHEADER;
 import dina.api.requests.CreateHTML;
 import dina.api.requests.CreatePDF;
 import dina.api.routes.AccessTmpRoute;
+import dina.api.routes.CreateHEADERRoute;
 import dina.api.routes.CreateHTMLRoute;
 import dina.api.routes.CreatePDFRoute;
 
@@ -144,7 +146,9 @@ public class Main {
 	    				 
 	    				if(format.equalsIgnoreCase("pdf"))
 	    					try {
+								System.out.println("createPDF");
 	    						CreatePDF c = new CreatePDF(op, req, res);
+								
 	    				        return c.result();
 	    					} catch (Exception e) {
 	    						// TODO Auto-generated catch block
@@ -152,8 +156,8 @@ public class Main {
 	    					}
 						if(format.equalsIgnoreCase("excel"))
 	    					try {
-								
 	    						CreateHEADER c = new CreateHEADER(op, req, res);
+								
 	    				        return c.result();
 								
 	    					} catch (Exception e) {
@@ -179,6 +183,13 @@ public class Main {
 		        
     			try {
 					CreateHTMLRoute.route(op);
+				} catch (Exception e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+
+				try {
+					CreateHEADERRoute.route(op);
 				} catch (Exception e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();

--- a/templates/Mammalia_labels.twig
+++ b/templates/Mammalia_labels.twig
@@ -3,6 +3,12 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
+<!--
+	Excel-Header:
+	{Header1,Header2,Header3,Header4}
+	Excel-Header-End
+-->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
     <title>Mammalia Labels</title>

--- a/templates/submit.html
+++ b/templates/submit.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <form action="/labels/v1.0/" method="POST">
-		<strong>Format: </strong><select name="format"><option value="html">HTML</option><option value="pdf">PDF</option></select>
+		<strong>Format: </strong><select name="format"><option value="html">HTML</option><option value="pdf">PDF</option><option value="excel">Excel-Header</option></select>
 		<strong>Template: </strong> <input type="text" name="template" value="template.html"/> <input type="submit" value="Send data"/>
 		<br/>
 		<strong>Data:</strong><br/>


### PR DESCRIPTION
### Now there is an extra option to just return the needed **Excel-Headers** from a Twig Template in the WebService.

**The Use is intended like this:**
Write the Excel-Headers that should be used in between "Excel-Headers:" and "Excel-Header-End" as HTML comment. 
Through String operations the headers are displayed for the user of the WebService. 